### PR TITLE
added warm start functionality for synthesis

### DIFF
--- a/src/Barycenters.jl
+++ b/src/Barycenters.jl
@@ -12,16 +12,19 @@ tol: positive float, convergence threshold
 n_steps: integer, determines how many steps are used for computing the geodesics which yield the tangent vector
 
 """
-function step_direction(ν, M, weights, Q; tol=1e-10, n_steps=100)
+function step_direction(ν, M, weights, Q; tol=1e-10, n_steps=100, prev_geodesics=nothing)
     tangent_vector = zeros(size(Q))
     p = size(M, 2)
     variance = 0
-    for i=1:p
-        gamma = discrete_transport(Q, ν, M[:, i], N = n_steps, tol=tol) 
-        tangent_vector = tangent_vector + weights[i] * (gamma.vector.m[1,:,:])
-        variance = variance + 0.5 * weights[i] * action(gamma)^2
+    geodesics = Vector{Any}(undef, p)
+    for i = 1:p
+        init  = isnothing(prev_geodesics) ? nothing : prev_geodesics[i]
+        gamma = discrete_transport(Q, ν, M[:, i], N=n_steps, tol=tol, initialization=init)
+        tangent_vector += weights[i] * gamma.vector.m[1,:,:]
+        variance       += 0.5 * weights[i] * action(gamma)^2
+        geodesics[i]    = gamma
     end
-    return tangent_vector, variance
+    return tangent_vector, variance, geodesics
 end
 
 
@@ -46,8 +49,9 @@ geodesic_steps: integer, determines how many steps are used for computing the ge
 function barycenter(M, weights, Q;
                     h=1., maxiters=100, tol=1e-8,
                     geodesic_tol=1e-10, geodesic_steps=100,
-                    return_stats=false, initialization_index=1, verbose=true)
-    ν = M[:,initialization_index]
+                    return_stats=false, initialization_index=1,
+                    initialization=nothing, geodesic_warmstart=true, verbose=true)
+    ν = isnothing(initialization) ? M[:,initialization_index] : copy(initialization)
     ν_next = copy(ν)
 
     root_steady_state = sqrt.(stationary_from_transition(Q))
@@ -57,10 +61,14 @@ function barycenter(M, weights, Q;
 
     prog = verbose ? Progress(maxiters; desc="WGD ", showspeed=true, color=:cyan) : nothing
 
+    prev_geodesics = nothing
+
     for k = 1:maxiters
 
-        δJ, variance = step_direction(ν, M, weights, Q,
-                                      tol=geodesic_tol, n_steps=geodesic_steps)
+        δJ, variance, geodesics = step_direction(ν, M, weights, Q,
+                                      tol=geodesic_tol, n_steps=geodesic_steps,
+                                      prev_geodesics=geodesic_warmstart ? prev_geodesics : nothing)
+        prev_geodesics = geodesics
         variances[k] = variance
         ν_next = ν .- (1 + 0.1 * randn())*h * graph_divergence(Q, metric_tensor(ν) .* δJ)
 
@@ -83,6 +91,30 @@ function barycenter(M, weights, Q;
 
     end
     return return_stats ? (ν_next, norm_diffs, variances) : ν_next
+end
+
+
+"""
+    iterated_barycenter(M, weights, Q; steps=[2,4,8,16,32], kwargs...)
+
+Warm-started barycenter computation. Runs `barycenter` repeatedly with the
+geodesic step counts in `steps` (doubling schedule by default), using each
+stage's output as the initialization for the next. The rationale is that
+starting gradient descent near the minimum means the expensive high-accuracy
+geodesic stages converge in far fewer iterations.
+
+All additional kwargs are forwarded to `barycenter` at every stage.
+"""
+function iterated_barycenter(M, weights, Q;
+                             steps=[2, 4, 8, 16, 32],
+                             kwargs...)
+    ν = nothing
+    for s in steps
+        verbose = get(kwargs, :verbose, true)
+        verbose && println("  → geodesic_steps = $s")
+        ν = barycenter(M, weights, Q; geodesic_steps=s, initialization=ν, kwargs...)
+    end
+    return ν
 end
 
 

--- a/src/EarthMover.jl
+++ b/src/EarthMover.jl
@@ -26,9 +26,17 @@ function discrete_transport(
     maxiters=2^16,
     tol=1e-10,
     progress=false,
+    initialization=nothing,
 )
-
-    a = chambolle_pock(Q, μ, ν, N, maxiters=maxiters, σ=σ, τ=τ, tol=tol, show_progress=progress)
+    if isnothing(initialization)
+        a = chambolle_pock(Q, μ, ν, N, maxiters=maxiters, σ=σ, τ=τ, tol=tol, show_progress=progress)
+    else
+        # Rebind the previous result to the new boundary conditions (μ, ν),
+        # reusing the cached linear systems since they only depend on Q and N.
+        new_cache = ErbarCache(initialization.cache, μ, ν)
+        warm = ErbarBundle(new_cache, copy(initialization.vector))
+        a = chambolle_pock(warm, maxiters=maxiters, σ=σ, τ=τ, tol=tol, show_progress=progress)
+    end
     return a
 end
 

--- a/src/ErbarVector.jl
+++ b/src/ErbarVector.jl
@@ -88,6 +88,13 @@ struct ErbarCache
 
         new(sparse(Q), μ, ν, π, N, ceh_sys, avg_sys)
     end
+
+    # Cheap constructor for warm-starting: reuse ceh_sys and avg_sys from an
+    # existing cache (they depend only on Q and N, not on μ or ν) and only
+    # update the boundary conditions.
+    function ErbarCache(existing::ErbarCache, μ_new::AbstractVector, ν_new::AbstractVector)
+        new(existing.Q, μ_new, ν_new, existing.π, existing.N, existing.ceh_sys, existing.avg_sys)
+    end
 end
 
 # An ErbarBundle is an ErbarCache together with an ErbarVector.
@@ -154,7 +161,7 @@ mutable struct ErbarBundle
 end
 
 
-Base.copy(a::ErbarCache) = ErbarCache(a.Q, a.μ, a.ν, a.N)
+Base.copy(a::ErbarCache) = ErbarCache(a, a.μ, a.ν)
 Base.copy(a::ErbarVector) = ErbarVector(copy(a.ρ), copy(a.m), copy(a.θ), copy(a.ρ_minus), copy(a.ρ_plus), copy(a.ρ_avg), copy(a.q))
 Base.copy(a::ErbarBundle) = ErbarBundle(copy(a.cache), copy(a.vector))
 

--- a/src/GraphTransportation.jl
+++ b/src/GraphTransportation.jl
@@ -39,6 +39,6 @@ include("EarthMover.jl")
 include("Barycenters.jl")
 
 # expose functionality for computing geodesics
-export discrete_transport, transport_cost, action, barycenter, analysis
+export discrete_transport, transport_cost, action, barycenter, iterated_barycenter, analysis
 
 end


### PR DESCRIPTION
added warmstart functionality
for a barycenter of p referenc measures, each descent iteration in the synthesis function requires us to compute p geodesics. assuming that \nu_k is not far from \nu_{k+1}, it seems reasonable to assume that the difference in norm between the geodesics connecting iterate \nu_{k} to each reference measure will not differ greatly from the respective geodesics connecting iterate \nu{k+1} to each reference measure, and that we can therefore pick a better initialization for the discrete_transport computation by recycling the most recently computed geodesics. this results in a modest speed up to the computation (1.5x, based on some small experiments)